### PR TITLE
feat: add ganache fork instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,17 +29,17 @@ yarn
 It's a good idea to try out your deployment on a fork before running it on mainnet. This will allow you to run the
 deployment in a forked environment and interact with it to ensure it works as expected.
 
-Start ganache:
+Start ganache.
 
 ```bash
 yarn ganache-fork your.node.url.io
 ```
 
 In a separate terminal, run the deployment script (it defaults to using localhost:8545 as the ETH node, which is
-desired in this case):
+desired in this case). Note: mnemonic is optional here -- without it, ganache will use its default pre-loaded account.
 
 ```bash
-node index.js --gasprice 50
+node index.js --gasprice 50 --mnemonic "your mnemonic (12 word seed phrase)"
 ```
 
 Now you should be able to use `localhost:8545` to interact with a forked version of mainnet (or kovan) where your
@@ -48,7 +48,7 @@ contract is deployed.
 ## Run the deployment script on mainnet or kovan
 
 ```bash
-node index.js --gasprice 50 --url your.node.url.io --mnemonic "your mnemonic"
+node index.js --gasprice 50 --url your.node.url.io --mnemonic "your mnemonic (12 word seed phrase)"
 ```
 
 ## Customize the script

--- a/README.md
+++ b/README.md
@@ -24,14 +24,32 @@ sudo apt-get update && sudo apt-get install -y libudev-dev libusb-1.0-0-dev
 yarn
 ```
 
-## Run the deployment script
+## Run the deployment script on a mainnet fork
+
+It's a good idea to try out your deployment on a fork before running it on mainnet. This will allow you to run the
+deployment in a forked environment and interact with it to ensure it works as expected.
+
+Start ganache:
+
+```bash
+yarn ganache-fork your.node.url.io
+```
+
+In a separate terminal, run the deployment script (it defaults to using localhost:8545 as the ETH node, which is
+desired in this case):
+
+```bash
+node index.js --gasprice 50
+```
+
+Now you should be able to use `localhost:8545` to interact with a forked version of mainnet (or kovan) where your
+contract is deployed.
+
+## Run the deployment script on mainnet or kovan
 
 ```bash
 node index.js --gasprice 50 --url your.node.url.io --mnemonic "your mnemonic"
 ```
-
-Note: this deployment script should work on mainnet and kovan. It should technically work on ganache forks of these
-networks as well, but in our testing, ganache has often returned false reverts during the deployment process.
 
 ## Customize the script
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "lint": "npm run eslint && npm run prettier -- --list-different",
     "lint-fix": "npm run eslint -- --fix && npm run prettier -- --write",
     "eslint": "eslint './**/*.js'",
-    "prettier": "prettier './**/*.js' './**/*.sol' './**/*.md'"
+    "prettier": "prettier './**/*.js' './**/*.sol' './**/*.md'",
+    "ganache-fork": "yarn ganache-cli -l 12000000 --fork"
   },
   "author": "UMA Team",
   "license": "AGPL-3.0",
@@ -19,7 +20,7 @@
     "eslint": "^7.9.0",
     "eslint-config-prettier": "^6.10.1",
     "eslint-plugin-prettier": "^3.1.2",
-    "ganache-cli": "^6.12.1",
+    "ganache-cli": "6.11.0",
     "husky": "^4.2.3",
     "lint-staged": "^10.5.3",
     "prettier": "1.19.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4078,10 +4078,10 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
-ganache-cli@^6.12.1:
-  version "6.12.1"
-  resolved "https://registry.yarnpkg.com/ganache-cli/-/ganache-cli-6.12.1.tgz#148cf6541494ef1691bd68a77e4414981910cb3e"
-  integrity sha512-zoefZLQpQyEJH9jgtVYgM+ENFLAC9iwys07IDCsju2Ieq9KSTLH89RxSP4bhizXKV/h/+qaWpfyCBGWnBfqgIQ==
+ganache-cli@6.11.0:
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/ganache-cli/-/ganache-cli-6.11.0.tgz#51e48312577f2a1be1bd17170779306989afe81c"
+  integrity sha512-bjvG93ao7YWhbZv1DFUnBi0pk589XIGiuSwYEn1wTxjnRfD6CNofVEzdYl1enTgidHY/3OtumTfaeGbrxbNKkg==
   dependencies:
     ethereumjs-util "6.2.1"
     source-map-support "0.5.12"


### PR DESCRIPTION
This adds instructions to deploy on a ganache fork.

A few notes:
- This adds a yarn script so the user only needs to provide their node url without providing other ganache arg boilerplate.
- This pins the version of ganache-cli due to a regression reported here: https://github.com/trufflesuite/ganache-core/issues/571#issuecomment-752715368.