### PR TITLE
fix: fix gas price multipication

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ if (argv.gasprice < 1 || argv.gasprice > 1000) throw "--gasprice must be between
   // Transaction parameters
   const transactionOptions = {
     gas: 12000000, // 12MM is very high. Set this lower if you only have < 2 ETH or so in your wallet.
-    gasPrice: argv.gasprice, // gasprice arg
+    gasPrice: argv.gasprice * 1000000000, // gasprice arg * GWEI
     from: account,
   };
 

--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ if (argv.gasprice < 1 || argv.gasprice > 1000) throw "--gasprice must be between
   // Transaction parameters
   const transactionOptions = {
     gas: 12000000, // 12MM is very high. Set this lower if you only have < 2 ETH or so in your wallet.
-    gasPrice: argv.gasprice * 1000000000, // gasprice arg * GWEI
+    gasPrice: argv.gasprice * 1000000000, // gasprice arg * 1 GWEI
     from: account,
   };
 


### PR DESCRIPTION
Gas price was previously not multiplied by 1 GWEI, so providing the argument within the required range would produce transactions with gas prices that were far too low.