### PR TITLE
(update): updating default parameters to work for Kovan instead of mainnet

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ if (argv.gasprice < 1 || argv.gasprice > 1000) throw "--gasprice must be between
   // Example EMP Parameters. Customize these.
   const empParams = {
     expirationTimestamp: "1640995200", // 01/01/2022 @ 0:00 (UTC)
-    collateralAddress: "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", // WETH
+    collateralAddress: "0xd0a1e359811322d97991e03f863a0c30c2cf029c", // Kovan WETH address
     priceFeedIdentifier: padRight(utf8ToHex("USDETH"), 64), // Using the USDETH price.
     syntheticName: "uUSDwETH Synthetic Token Expiring 1 January 2022", // Long name.
     syntheticSymbol: "uUSDwETH-JAN", // Short name.
@@ -43,7 +43,7 @@ if (argv.gasprice < 1 || argv.gasprice > 1000) throw "--gasprice must be between
     minSponsorTokens: { rawValue: toWei("100") }, // Min sponsor position size of 100 synthetic tokens.
     liquidationLiveness: 7200, // 2 hour liquidation liveness.
     withdrawalLiveness: 7200, // 2 hour withdrawal liveness.
-    excessTokenBeneficiary: "0x54f44eA3D2e7aA0ac089c4d8F7C93C27844057BF", // UMA Store contract.
+    excessTokenBeneficiary: "0x41AF40Eb92Bec4dD8DA77103597838b3dBBD3B6f", // UMA Kovan Store contract.
   };
 
   const accounts = await web3.eth.getAccounts();

--- a/index.js
+++ b/index.js
@@ -29,10 +29,16 @@ if (argv.gasprice < 1 || argv.gasprice > 1000) throw "--gasprice must be between
   const web3 = new Web3(argv.mnemonic ? new HDWalletProvider(hdwalletOptions) : url);
   const { toWei, utf8ToHex, padRight } = web3.utils;
 
+  const accounts = await web3.eth.getAccounts();
+  if (!accounts || accounts.length === 0)
+    throw "No accounts. Must provide mnemonic or node must have unlocked accounts.";
+  const account = accounts[0];
+  const networkId = await web3.eth.net.getId();
+
   // Example EMP Parameters. Customize these.
   const empParams = {
     expirationTimestamp: "1640995200", // 01/01/2022 @ 0:00 (UTC)
-    collateralAddress: "0xd0a1e359811322d97991e03f863a0c30c2cf029c", // Kovan WETH address
+    collateralAddress: "0xd0a1e359811322d97991e03f863a0c30c2cf029c", // Kovan WETH address. Mainnet WETH is: 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.
     priceFeedIdentifier: padRight(utf8ToHex("USDETH"), 64), // Using the USDETH price.
     syntheticName: "uUSDwETH Synthetic Token Expiring 1 January 2022", // Long name.
     syntheticSymbol: "uUSDwETH-JAN", // Short name.
@@ -43,14 +49,9 @@ if (argv.gasprice < 1 || argv.gasprice > 1000) throw "--gasprice must be between
     minSponsorTokens: { rawValue: toWei("100") }, // Min sponsor position size of 100 synthetic tokens.
     liquidationLiveness: 7200, // 2 hour liquidation liveness.
     withdrawalLiveness: 7200, // 2 hour withdrawal liveness.
-    excessTokenBeneficiary: "0x41AF40Eb92Bec4dD8DA77103597838b3dBBD3B6f", // UMA Kovan Store contract.
+    excessTokenBeneficiary:  getAddress("Store", networkId), // UMA Store contract.
   };
 
-  const accounts = await web3.eth.getAccounts();
-  if (!accounts || accounts.length === 0)
-    throw "No accounts. Must provide mnemonic or node must have unlocked accounts.";
-  const account = accounts[0];
-  const networkId = await web3.eth.net.getId();
   const empCreator = new web3.eth.Contract(
     getAbi("ExpiringMultiPartyCreator"),
     getAddress("ExpiringMultiPartyCreator", networkId)


### PR DESCRIPTION
This PR is to update the default EMP parameters to be Kovan specific rather than mainnet specific. I think a lot of people will follow this tutorial without complete thought around the design necessary for a mainnet contract, so I think it is a better approach to create a barrier to mainnet launch where they will have to edit the parameters before deploying to mainnet.

I edited collateralAddress to the Kovan WETH address, and excessTokenBeneficiary to the Kovan store.