### PR TITLE
Modify EMP to allow for covered calls

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ const libraryAddress = argv.libraryAddress ? argv.libraryAddress : "0x0000000000
                                                      // before expiry, as defined in the financialProductLibrary
     disputeBondPercentage: { rawValue: toWei("0.1") }, // 10% dispute bond.
     sponsorDisputeRewardPercentage: { rawValue: toWei("1") }, // 100% reward for sponsors who are disputed invalidly (sponsors should never be disputed)
-    disputerDisputeRewardPercentage: { rawValue: toWei("0.2") }, // 0% reward for correct disputes (disputes should always be wrong).
+    disputerDisputeRewardPercentage: { rawValue: "0" }, // 0% reward for correct disputes (disputes should always be right).
     minSponsorTokens: { rawValue: parseFixed(argv.minSponsorTokens.toString(), decimals) }, // Minimum sponsor position size.
     liquidationLiveness: 5184000, // 60 day liquidation liveness.
     withdrawalLiveness: 5184000, // 60 day withdrawal liveness.

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ if (!argv.minSponsorTokens) throw "--minSponsorTokens required";
 if (!argv.gasprice) throw "--gasprice required (in GWEI)";
 if (typeof argv.gasprice !== "number") throw "--gasprice must be a number";
 if (argv.gasprice < 1 || argv.gasprice > 1000) throw "--gasprice must be between 1 and 1000 (GWEI)";
-const libraryAddress = argv.libraryAddress ? argv.libraryAddress : "0x0000000000000000000000000000000000000000";
+const libraryAddress = argv.libraryAddress ? argv.libraryAddress : "0xb0A395D8F3ae483d757EC1c83eFFc61DF96eCfa4";
 
 // Wrap everything in an async function to allow the use of async/await.
 (async () => {

--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ const libraryAddress = argv.libraryAddress ? argv.libraryAddress : "0x0000000000
     collateralRequirement: { rawValue: toWei("1") }, // 100% collateral req is possible because position is always backed by 1 unit of colateral, as 
                                                      // before expiry, as defined in the financialProductLibrary
     disputeBondPercentage: { rawValue: toWei("0.1") }, // 10% dispute bond.
-    sponsorDisputeRewardPercentage: { rawValue: toWei("1") }, // 100% reward for sponsors who are disputed invalidly (sponsors should never be disputed)
+    sponsorDisputeRewardPercentage: { rawValue: toWei("0.99999") }, // 100% reward for sponsors who are disputed invalidly (sponsors should never be disputed)
     disputerDisputeRewardPercentage: { rawValue: "0" }, // 0% reward for correct disputes (disputes should always be right).
     minSponsorTokens: { rawValue: parseFixed(argv.minSponsorTokens.toString(), decimals) }, // Minimum sponsor position size.
     liquidationLiveness: 5184000, // 60 day liquidation liveness.

--- a/index.js
+++ b/index.js
@@ -67,14 +67,16 @@ const libraryAddress = argv.libraryAddress ? argv.libraryAddress : "0x0000000000
     priceFeedIdentifier: padRight(utf8ToHex(argv.priceFeedIdentifier.toString()), 64), // Price identifier to use.
     syntheticName: argv.syntheticName, // Long name.
     syntheticSymbol: argv.syntheticSymbol, // Short name.
-    collateralRequirement: { rawValue: toWei("1.25") }, // 125% collateral req.
+    
+    collateralRequirement: { rawValue: toWei("1") }, // 100% collateral req is possible because position is always backed by 1 unit of colateral, as 
+                                                     // before expiry, as defined in the financialProductLibrary
     disputeBondPercentage: { rawValue: toWei("0.1") }, // 10% dispute bond.
-    sponsorDisputeRewardPercentage: { rawValue: toWei("0.05") }, // 5% reward for sponsors who are disputed invalidly
-    disputerDisputeRewardPercentage: { rawValue: toWei("0.2") }, // 20% reward for correct disputes.
+    sponsorDisputeRewardPercentage: { rawValue: toWei("1") }, // 100% reward for sponsors who are disputed invalidly (sponsors should never be disputed)
+    disputerDisputeRewardPercentage: { rawValue: toWei("0.2") }, // 0% reward for correct disputes (disputes should always be wrong).
     minSponsorTokens: { rawValue: parseFixed(argv.minSponsorTokens.toString(), decimals) }, // Minimum sponsor position size.
-    liquidationLiveness: 7200, // 2 hour liquidation liveness.
-    withdrawalLiveness: 7200, // 2 hour withdrawal liveness.
-    financialProductLibraryAddress: libraryAddress, // Default to 0x0 if no address is passed.
+    liquidationLiveness: 5184000, // 60 day liquidation liveness.
+    withdrawalLiveness: 5184000, // 60 day withdrawal liveness.
+    financialProductLibraryAddress: libraryAddress, // this is required for covered calls
   };
 
   const empCreator = new web3.eth.Contract(

--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ const libraryAddress = argv.libraryAddress ? argv.libraryAddress : "0x0000000000
     syntheticName: argv.syntheticName, // Long name.
     syntheticSymbol: argv.syntheticSymbol, // Short name.
     
-    collateralRequirement: { rawValue: toWei("1") }, // 100% collateral req is possible because position is always backed by 1 unit of colateral, as 
+    collateralRequirement: { rawValue: web3.utils.toBN(toWei("1")).addn(1).toString() }, // 100% collateral req is possible because position is always backed by 1 unit of colateral, as 
                                                      // before expiry, as defined in the financialProductLibrary
     disputeBondPercentage: { rawValue: toWei("0.1") }, // 10% dispute bond.
     sponsorDisputeRewardPercentage: { rawValue: toWei("0.99999") }, // 100% reward for sponsors who are disputed invalidly (sponsors should never be disputed)


### PR DESCRIPTION
Modify the EMP such that disputes and withdrawals are effectively disabled until expiry.

Our goal here is to create covered calls where each option token is backed by 1 underlyer token. This means that ideally withdrawals should be impossible, liquidations should be impossible. At expiry each option token gets a fraction of the underlyer.
We can’t make withdrawals and liquidations impossible but we can get close. To do this we want to:

1. Set the `withdrawalLiveness` to 60 days
2. Set the `liquidationLiveness` to 60 days
3. Set the `sponsorDisputeRewardPercentage` to 100% (liquidator loses all capital for invalid liquidation, which by definition is any liquidation)
4. Set the `disputerDisputeRewardPercentage` to 0% (disputer gets no rewards for any dispute, because all value should flow to the sponsor who should never be liquidated in the first place)
5. Set the `collateralRequirement` to 100%.

The token should use our new `financialProductLibraryAddress` functionality to define a payout that is (for call options) that does the following (written in pseudocode because I don't know Solidity):

```
function transformCollateralRequirement(FixedPoint.Unsigned memory oraclePrice, FixedPoint.Unsigned memory collateralRequirement) 
    public view virtual returns (FixedPoint.Unsigned memory) 
{
    return 1;  // always return 1 because option must be collateralized by 1 token
}
```

```
function transformPrice(FixedPoint.Unsigned memory oraclePrice, uint256 requestTime)
    public view virtual returns (FixedPoint.Unsigned memory)
{
    if (requestTime < expirationTimestamp) {
        return 1;  // pay out a full UMA token
    }
    else {
        // pay out the fraction of an UMA token that's in the money, or 0 if out of the money.
        return MAX( (oraclePrice - STRIKE_PRICE) / oraclePrice, 0); 
    }
}
```
Note that `STRIKE_PRICE` needs to be hardcoded in this library.