### PR TITLE
update readme for Mac install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ deployment in a forked environment and interact with it to ensure it works as ex
 
 Start ganache.
 
+EDIT to eng: What's your.node.url.io? We need to spell this out in more detail. We should also have a link to Ganache and a one sentence explaination about what it is.
+
 ```bash
 yarn ganache-fork your.node.url.io
 ```

--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ yarn
 
 ## Run the deployment script on a mainnet fork
 
-It's a good idea to try out your deployment on a fork before running it on mainnet. This will allow you to run the
-deployment in a forked environment and interact with it to ensure it works as expected.
+It's a good idea to try out your deployment on a fork before running it on mainnet. This will allow you to run the deployment in a forked environment and interact with it to ensure it works as expected. To do this, you will use [Gananche](https://www.trufflesuite.com/ganache), a tool that allows for the creation of local Ethereum test networks. 
 
 Start ganache.
 
@@ -53,4 +52,4 @@ node index.js --gasprice 50 --url YOUR_NODE_URL --mnemonic "your mnemonic (12 wo
 
 ## Customize your deployment parameters
 
-It is recommended to keep the default empParams struct and only customize your construction parameters by passing in the listed mandatory args. See [the script](./index.js) or this [documentation](https://docs.umaproject.org/build-walkthrough/emp-parameters) for more details.
+It is recommended to keep the default empParams struct and only customize your construction parameters by passing in the listed mandatory args. See [the script](./index.js) or [documentation](https://docs.umaproject.org/build-walkthrough/emp-parameters) for more details.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ repository in place or fork and customize it.
 
 ## Install system dependencies
 
-You will need to install nodejs (we recommend the latest stable version, nodejs v14, and `nvm` to manage node versions) and yarn.
+You will need to install nodejs v12 (we recommend `nvm` to manage node versions) and yarn.
 
 Note: these additional dependencies are required -- you may or may not have them on your system already:
 
@@ -31,10 +31,8 @@ deployment in a forked environment and interact with it to ensure it works as ex
 
 Start ganache.
 
-EDIT to eng: What's your.node.url.io? We need to spell this out in more detail. We should also have a link to Ganache and a one sentence explaination about what it is.
-
 ```bash
-yarn ganache-fork your.node.url.io
+yarn ganache-fork YOUR_NODE_URL
 ```
 
 In a separate terminal, run the deployment script (it defaults to using localhost:8545 as the ETH node, which is
@@ -50,13 +48,9 @@ contract is deployed.
 ## Run the deployment script on mainnet or kovan
 
 ```bash
-node index.js --gasprice 50 --url your.node.url.io --mnemonic "your mnemonic (12 word seed phrase)" --priceFeedIdentifier USDETH --collateralAddress "0xd0a1e359811322d97991e03f863a0c30c2cf029c" --expirationTimestamp "1643678287" --syntheticName "Yield Dollar [WETH Jan 2022]" --syntheticSymbol "YD-ETH-JAN22" --minSponsorTokens "100"
+node index.js --gasprice 50 --url YOUR_NODE_URL --mnemonic "your mnemonic (12 word seed phrase)" --priceFeedIdentifier USDETH --collateralAddress "0xd0a1e359811322d97991e03f863a0c30c2cf029c" --expirationTimestamp "1643678287" --syntheticName "Yield Dollar [WETH Jan 2022]" --syntheticSymbol "YD-ETH-JAN22" --minSponsorTokens "100"
 ```
 
-## Customize the script
+## Customize your deployment parameters
 
-The script should be fairly easy to read and understand. It is recommended to keep the default empParams 
-and customize your construction parameters by passing the listed mandatory args. See [the script](./index.js) 
-for more details.
-
-We encourage you to fork this repo and customize the script as you see fit!
+It is recommended to keep the default empParams struct and only customize your construction parameters by passing in the listed mandatory args. See [the script](./index.js) or this [documentation](https://docs.umaproject.org/build-walkthrough/emp-parameters) for more details.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ yarn
 
 ## Run the deployment script on a mainnet fork
 
-It's a good idea to try out your deployment on a fork before running it on mainnet. This will allow you to run the deployment in a forked environment and interact with it to ensure it works as expected. To do this, you will use [Gananche](https://www.trufflesuite.com/ganache), a tool that allows for the creation of local Ethereum test networks. 
+It's a good idea to try out your deployment on a fork before running it on mainnet. This will allow you to run the deployment in a forked environment and interact with it to ensure it works as expected. To do this, you will use [Gananche](https://www.trufflesuite.com/ganache), a tool that allows for the creation of local Ethereum test networks.
+
+You should replace `YOUR_NODE_URL` with the URL of whatever Kovan or mainnet Ethereum node that you wish to use. [Infura](https://infura.io/product/ethereum) provides easy access to Ethereum and is one method that you could use to get your node URL.
 
 Start ganache.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Note: these additional dependencies are required -- you may or may not have them
 - `libudev`
 - `libusb`
 
-Example ubuntu installation command for additional deps:
+These dependencies are installed on MacOSX by installing the XCode Developer Tools. For Linux, the example ubuntu installation command for additional deps is:
 
 ```bash
 sudo apt-get update && sudo apt-get install -y libudev-dev libusb-1.0-0-dev


### PR DESCRIPTION
Update the readme to say that dependencies are installed on Mac via Xcode Tools