### PR TITLE
build(ganache-cli): bump version to v6.12.0 to fix node 14 errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/UMAprotocol/launch-emp.git"
   },
   "devDependencies": {
-    "ganache-cli": "6.11.0",
+    "ganache-cli": "6.12.0",
     "prettier": "^2.2.1"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4762,10 +4762,10 @@ functional-red-black-tree@^1.0.1, functional-red-black-tree@~1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
-ganache-cli@6.11.0:
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/ganache-cli/-/ganache-cli-6.11.0.tgz#51e48312577f2a1be1bd17170779306989afe81c"
-  integrity sha512-bjvG93ao7YWhbZv1DFUnBi0pk589XIGiuSwYEn1wTxjnRfD6CNofVEzdYl1enTgidHY/3OtumTfaeGbrxbNKkg==
+ganache-cli@6.12.0:
+  version "6.12.0"
+  resolved "https://registry.yarnpkg.com/ganache-cli/-/ganache-cli-6.12.0.tgz#0cfe3ae2287b2bb036c1ec1fa7360c1ff837535b"
+  integrity sha512-WV354mOSCbVH+qR609ftpz/1zsZPRsHMaQ4jo9ioBQAkguYNVU5arfgIE0+0daU0Vl9WJ/OMhRyl0XRswd/j9A==
   dependencies:
     ethereumjs-util "6.2.1"
     source-map-support "0.5.12"


### PR DESCRIPTION
version 6.12.0 includes fixes for Node 14 - https://github.com/trufflesuite/ganache-cli/issues/732#issuecomment-708056624

In node 14, while trying to test deployment script on fork using `yarn ganache-fork wss://kovan.infura.io/ws/v3/<PROJECT_ID>`
kept getting `Error: Callback was already called.`